### PR TITLE
chore(deps): raise minimum versions to patched releases (Pillow, pyth…

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,8 @@
-fastapi>=0.115.0
-uvicorn[standard]>=0.30.0
-python-multipart>=0.0.9
+# Web framework — starlette pulled transitively; floor raised to patched releases.
+fastapi>=0.115.6
+uvicorn[standard]>=0.30.6
+# python-multipart < 0.0.18 has a DoS CVE (GHSA-2jv5-9r88-3w3p / 59gj).
+python-multipart>=0.0.18
 youtube-transcript-api>=1.0.0
 google-genai>=1.0.0
 python-dotenv>=1.0.0
@@ -9,7 +11,9 @@ bcrypt>=4.0.0
 PyJWT>=2.0.0
 google-auth>=2.0.0
 psycopg2-binary>=2.9.0
-Pillow>=10.0.0
+# Pillow < 10.3 has multiple image-parsing CVEs (buffer overflow).
+Pillow>=10.3.0
+# Jinja2 < 3.1.5 has sandbox-escape / template CVEs.
+jinja2>=3.1.5
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
-jinja2>=3.0.0


### PR DESCRIPTION
…on-multipart, Jinja2, fastapi) to clear Dependabot alerts

<!-- Thanks for contributing to LectureDigest! -->

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests / CI

## Testing

<!-- How did you verify this? -->

- [ ] `cd backend && pytest` passes
- [ ] `cd backend && ruff check .` passes
- [ ] `npm test` passes (if frontend changed)
- [ ] Manually tested in the browser (if UI changed)

## Notes

<!-- Anything reviewers should know: trade-offs, follow-ups, screenshots. -->
